### PR TITLE
Don't attempt to parse a name that has no spaces

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -59,7 +59,10 @@ class HumanNameParser_Parser {
 			  $this->prefixes = array('bar','ben','bin','da','dal','de la', 'de', 'del','der','di',
 							'ibn','la','le','san','st','ste','van', 'van der', 'van den', 'vel','von');
 
-			  $this->parse();
+			  // We can only parse if there are spaces in the name
+			  if (strstr($name, " ") !== false) {
+				$this->parse();
+			  }
 		  }
 	  }
 	  
@@ -84,9 +87,10 @@ class HumanNameParser_Parser {
 	  public function getSuffix() {
 		  return $this->suffix;
 	  }
-          public function getName(){
-              return $this->name;
-          }
+
+      public function getName(){
+          return $this->name;
+      }
 
 	  /**
 	   * returns all the parts of the name as an array

--- a/Tests/NameTest.php
+++ b/Tests/NameTest.php
@@ -1,13 +1,11 @@
 <?php
-require_once 'PHPUnit/Framework.php';
 require_once dirname(__FILE__).'/../Name.php';
-
 class NameTest extends PHPUnit_Framework_TestCase {
 
 	protected $object;
 
 	protected function setUp() {
-		$this->object = new Name("Björn O'Malley");
+		$this->object = new HumanNameParser_Name("Björn O'Malley");
 	}
 
 	public function testSetStrRemovesWhitespaceAtEnds() {
@@ -66,9 +64,6 @@ class NameTest extends PHPUnit_Framework_TestCase {
 				  $this->object->getStr()
 				  );
 	}
-
-
-
 
 }
 ?>

--- a/Tests/ParserTest.php
+++ b/Tests/ParserTest.php
@@ -1,0 +1,22 @@
+<?php
+require_once dirname(__FILE__).'/../init.php';
+
+class ParserTest extends PHPUnit_Framework_TestCase {
+
+	public function testSingleName() {
+		$parser = new HumanNameParser_Parser("Björn");
+		$this->assertEquals(
+			"Björn",
+			$parser->getName()->getStr()
+		);
+		$this->assertEquals(
+			null,
+			$parser->getFirst()
+		);
+		$this->assertEquals(
+			null,
+			$parser->getLast()
+		);
+	}
+}
+

--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,8 @@
   "description": "Takes human names of arbitrary complexity and various wacky formats and parses them out.",
   "autoload": {
         "classmap": ["Name.php", "Parser.php"]
+  },
+  "require-dev": {
+          "phpunit/phpunit": "4.5.*"
   }
 }


### PR DESCRIPTION
If a name doesn't have any spaces in it then we can't know if it's a first,
last, nick, suffix, prefix etc. So, just leave it as the nameStr and don't call
the parse function.

While here, update the unit tests to add a case for a single name, and add phpunit to composer.json.
I also had some difficulty running the unit tests at all, I needed to change the
class names to match what was in the code.
